### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A cog implementation of LivePortrait using the ComfyUI custom node
 - Paper: https://arxiv.org/pdf/2407.03168
 - Website: https://liveportrait.github.io/
 
+[![Try a demo on Replicate](https://replicate.com/fofr/live-portrait/badge)](https://replicate.com/fofr/live-portrait)
+
 ## Example driving videos
 
 Try these videos:


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.